### PR TITLE
Preserve file ownership when rewriting input ebuild

### DIFF
--- a/pycargoebuild/__main__.py
+++ b/pycargoebuild/__main__.py
@@ -397,6 +397,8 @@ def main(prog_name: str, *argv: str) -> int:
                                      delete=False) as outf:
         try:
             if args.input is not None:
+                st = os.stat(args.input.fileno())
+                os.chown(outf.fileno(), st.st_uid, st.st_gid)
                 # typeshed is missing fd support in shutil.copymode()
                 # https://github.com/python/typeshed/issues/9288
                 shutil.copymode(args.input.fileno(),

--- a/pycargoebuild/__main__.py
+++ b/pycargoebuild/__main__.py
@@ -9,7 +9,7 @@ import json
 import logging
 import lzma
 import os.path
-import shutil
+import stat
 import subprocess
 import sys
 import tarfile
@@ -399,10 +399,7 @@ def main(prog_name: str, *argv: str) -> int:
             if args.input is not None:
                 st = os.stat(args.input.fileno())
                 os.chown(outf.fileno(), st.st_uid, st.st_gid)
-                # typeshed is missing fd support in shutil.copymode()
-                # https://github.com/python/typeshed/issues/9288
-                shutil.copymode(args.input.fileno(),
-                                outf.fileno())  # type: ignore
+                os.chmod(outf.fileno(), stat.S_IMODE(st.st_mode))
                 args.input.close()
             else:
                 os.fchmod(outf.fileno(), 0o666 & ~umask)


### PR DESCRIPTION
If `sudo pycargoebuild` is used, e.g. to store downloaded crates in /var/cache/distfiles, the ebuild file ends up chowned to root since it is atomically rewritten. Explicitly chown it back.