### PR TITLE
cargo.py: default to 0.0.0 if version field is missing

### DIFF
--- a/pycargoebuild/cargo.py
+++ b/pycargoebuild/cargo.py
@@ -300,9 +300,11 @@ def get_package_metadata(f: typing.BinaryIO,
     if pkg_license is not None:
         pkg_license = cargo_to_spdx(pkg_license)
 
+    #missing version field is legal in rust >= 1.75 and defaults to 0.0.0:
+    #https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field
     pkg_version = _get_meta_key("version")
     if pkg_version is None:
-        raise ValueError(f"No version found in {f.name}")
+        pkg_version = "0.0.0"
 
     features = cargo_toml.get("features", {})
     default_features = features.pop("default", [])

--- a/test/test_cargo.py
+++ b/test/test_cargo.py
@@ -237,6 +237,17 @@ def test_get_package_metadata_features():
                             license_file="COPYING"))
 
 
+def test_get_package_metadata_default_version():
+    input_toml = """
+        [package]
+        name = "test"
+    """
+
+    assert (get_package_metadata(io.BytesIO(input_toml.encode("utf-8"))) ==
+            PackageMetadata(name="test",
+                            version="0.0.0"))
+
+
 TOP_CARGO_TOML = b"""\
 [package]
 name = "toplevel"


### PR DESCRIPTION
Starting with Rust 1.75, the [version] field in cargo manifests is no longer mandatory, defaulting to 0.0.0 if unset.(1)

Fixes: #42

(1) https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field