### PR TITLE
Use static.crates.io for downloads

### DIFF
--- a/integration_test/test_integration.py
+++ b/integration_test/test_integration.py
@@ -131,7 +131,7 @@ PACKAGES = {
         uses_license_file=True,
         uses_plus_fallback=True),
     "rustls-0.20.7.ebuild": Package(
-        url="https://crates.io/api/v1/crates/rustls/0.20.7/download",
+        url="https://static.crates.io/crates/rustls/0.20.7/download",
         checksum="539a2bfe908f471bfa933876bd1eb6a1"
                  "9cf2176d375f82ef7f99530a40e48c2c",
         directories=["rustls-0.20.7"],

--- a/pycargoebuild/cargo.py
+++ b/pycargoebuild/cargo.py
@@ -49,7 +49,7 @@ class FileCrate(Crate):
 
     @property
     def download_url(self) -> str:
-        return (f"https://crates.io/api/v1/crates/{self.name}/{self.version}/"
+        return (f"https://static.crates.io/crates/{self.name}/{self.version}/"
                 "download")
 
     @property


### PR DESCRIPTION
As described in #47, crates.io recommends using `static.crates.io` for downloads (https://github.com/rust-lang/crates.io/issues/13482#issuecomment-4304855751).